### PR TITLE
Ensure result materializes before exit

### DIFF
--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -1,9 +1,17 @@
-object Tables extends{ // or just use object demo.Tables, which is hard-wired to the driver stated during generation
-  val profile = scala.slick.driver.H2Driver  
+object Tables extends {
+  // or just use object demo.Tables, which is hard-wired to the driver stated during generation
+  val profile = scala.slick.driver.H2Driver
 } with demo.Tables
+
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 import Tables._
 import Tables.profile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
+
 
 object Example extends App {
   // connection info for a pre-populated throw-away, in-memory db for this demo, which is freshly initialized on every run
@@ -12,12 +20,12 @@ object Example extends App {
 
   // Using generated code. Our Build.sbt makes sure they are generated before compilation.
   val q = Companies.join(Computers).on(_.id === _.manufacturerId)
-                   .map{ case (co,cp) => (co.name, cp.name) }
+    .map { case (co, cp) => (co.name, cp.name) }
 
-  db.run(q.result).foreach { result =>
-    println(result.groupBy{ case (co,cp) => co }
-                  .mapValues(_.map{ case (co,cp) => cp })
-                  .mkString("\n")
+  Await.result(db.run(q.result).map { result =>
+    println(result.groupBy { case (co, cp) => co }
+      .mapValues(_.map { case (co, cp) => cp })
+      .mkString("\n")
     )
-  }
+  }, 60 seconds)
 }


### PR DESCRIPTION
On Java 8 w/ Scala 2.11.7, previous version would exit w/o printing the
results. Wrapping in an await makes sure this doesn't happen.